### PR TITLE
Return options from notifier

### DIFF
--- a/Ui/Source/Notifiers.php
+++ b/Ui/Source/Notifiers.php
@@ -1,22 +1,29 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\AsyncEventsAdminUi\Ui\Source;
 
-class Notifiers implements \Magento\Framework\Option\ArrayInterface
+use \MageOS\AsyncEvents\Service\AsyncEvent\NotifierFactoryInterface;
+
+class Notifiers implements \Magento\Framework\Data\OptionSourceInterface
 {
+    public function __construct(private readonly NotifierFactoryInterface $notifierFactory) {}
+
     /**
-     * Options are hard coded since this module only support HTTP
-     *
      * @return array[]
      */
     public function toOptionArray()
     {
-        return [
-            [
-                'value' => 'http',
-                'label' => 'HTTP',
-            ]
-        ];
+        $options = [];
+
+        foreach ($this->notifierFactory->getSinks() as $sink) {
+            $options[] = [
+                'value' => $sink,
+                'label' => $sink,
+            ];
+        }
+
+        return $options;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "require": {
     "php":  ">=8.1",
     "magento/framework": "*",
-    "mage-os/mageos-async-events": "*"
+    "mage-os/mageos-async-events": "^4.0.2"
   },
   "repositories": [
     {


### PR DESCRIPTION
Since async events [v4.0.2](https://github.com/mage-os/mageos-async-events/releases/tag/v4.0.2) the notifier factory interface has had a new helper method `NotifierFactoryInterface::getSinks()` which is perfect for use cases like this.

The admin UI module now does not need to rely on the notifier modules adding a plugin to the option arrays. This was prone to errors and was redundant. 